### PR TITLE
Add custom error handler

### DIFF
--- a/loafer/dispatcher.py
+++ b/loafer/dispatcher.py
@@ -59,9 +59,7 @@ class LoaferDispatcher(object):
                 logger.warning(msg.format(route.message_handler, message))
                 return False
             except Exception as exc:
-                logger.exception(exc)
-                logger.error('Unhandled exception on {}'.format(route.message_handler))
-                return False
+                return route.error_handler(content, exc)
 
         return True
 

--- a/loafer/route.py
+++ b/loafer/route.py
@@ -32,3 +32,13 @@ class Route(object):
             logger.debug('Handler will run in a separate thread: {!r}'.format(self.message_handler_name))
             loop = loop or asyncio.get_event_loop()
             return await loop.run_in_executor(None, self.message_handler, content)
+
+    def error_handler(self, message, exception):
+        """Hook for unhandled exceptions raised from `message_handler` for a given
+        message.
+        If the returning value is True, the message will be acknowledged.
+        By the default we return `False`.
+        """
+        logger.exception(exception)
+        logger.error('Unhandled exception on {}'.format(self.message_handler))
+        return False

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -4,7 +4,6 @@ import asyncio
 from unittest.mock import Mock
 
 from asynctest import CoroutineMock
-#from asynctest import Mock as AsyncMock  # flake8: NOQA
 import pytest
 
 from loafer.exceptions import RejectMessage, IgnoreMessage
@@ -165,6 +164,7 @@ async def test_dispatch_message_task_cancel(route, event_loop):
     assert route.deliver.called
     assert route.deliver.called_once_with(message)
 
+
 def test_dispatch_consumers(route, consumer, event_loop):
     routes = [route]
     dispatcher = LoaferDispatcher(routes, [Mock()], loop=event_loop)
@@ -176,7 +176,6 @@ def test_dispatch_consumers(route, consumer, event_loop):
 
     def stopper():
         return running_values.pop(0)
-
 
     event_loop.run_until_complete(dispatcher.dispatch_consumers(stopper))
 

--- a/tests/test_route.py
+++ b/tests/test_route.py
@@ -40,6 +40,12 @@ def test_default_message_translator():
     assert isinstance(translator, SNSMessageTranslator)
 
 
+def test_default_error_handler():
+    route = Route('foo', example_job)
+    assert callable(route.error_handler)
+    assert route.error_handler('message', mock.Mock()) is False
+
+
 # FIXME: Improve all test_deliver* tests
 
 @pytest.mark.asyncio


### PR DESCRIPTION
A utilidade dessa alteração é para podermos definir algo +/- assim no broker:

```
class RouteWithSentry(Route):
    def error_handler(self, *args, **kwargs):
        raven_client.captureException()
        return True  # remove message from queue
```